### PR TITLE
Using thiserror instead of failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ reqwest = { version = "0.10", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
-failure = "0.1.1"
-failure_derive = "0.1.1"
+thiserror = "1.0"
 lazy_static = "1.1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Failure is deprecated. I have implemented errors using `thiserror`.