### PR TITLE
Update document object - make preview optional.

### DIFF
--- a/src/objects/document.rs
+++ b/src/objects/document.rs
@@ -14,7 +14,7 @@ pub struct Document {
     #[serde(rename = "type")]
     pub type_: Integer,
 
-    pub preview: DocumentPreview,
+    pub preview: Option<DocumentPreview>,
 
     /// Access key may be present in attachments
     /// (


### PR DESCRIPTION
Looks like `preview` field should be optional:
```
thread 'main' panicked at 'Failed to get posts.: "Failed to parse VK wall: Error(\"missing field `preview`\", line: 0, column: 0)"', src/main.rs:54:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```