### PR TITLE
Replacement of Integer Photo id with string

### DIFF
--- a/src/objects/photo.rs
+++ b/src/objects/photo.rs
@@ -3,7 +3,7 @@ use super::*;
 /// <https://vk.com/dev/objects/photo>
 #[derive(Deserialize, Clone, Debug)]
 pub struct Photo {
-    pub id: Integer,
+    pub id: String,
     pub album_id: Option<Integer>,
     pub owner_id: Option<Integer>,
     pub user_id: Option<Integer>,


### PR DESCRIPTION
Looks like VK made Photo Id a string instead of integer:
```
Error(\"invalid type: string \\\"257237449\\\", expected i64\"
```