### PR TITLE
Make Comments.groups_can_post optional

### DIFF
--- a/src/objects/post.rs
+++ b/src/objects/post.rs
@@ -39,7 +39,7 @@ pub struct Post {
 pub struct Comments {
     pub count: Integer,
     pub can_post: Integer,
-    pub groups_can_post: Option<Boolean>,
+    pub groups_can_post: Option<Integer>,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/objects/post.rs
+++ b/src/objects/post.rs
@@ -39,7 +39,7 @@ pub struct Post {
 pub struct Comments {
     pub count: Integer,
     pub can_post: Integer,
-    pub groups_can_post: Boolean,
+    pub groups_can_post: Option<Boolean>,
 }
 
 #[derive(Deserialize, Clone, Debug)]


### PR DESCRIPTION
Sometimes (even in the example on https://vk.com/dev/wall.get) groups_can_post field is absent. I've never got this field present in wall.get and am always getting serde error "missing field `groups_can_post`")