### PR TITLE
groups_can_post field is boolean

### DIFF
--- a/src/objects/post.rs
+++ b/src/objects/post.rs
@@ -39,7 +39,7 @@ pub struct Post {
 pub struct Comments {
     pub count: Integer,
     pub can_post: Integer,
-    pub groups_can_post: Option<Integer>,
+    pub groups_can_post: Option<Boolean>,
 }
 
 #[derive(Deserialize, Clone, Debug)]


### PR DESCRIPTION
`Error(\"invalid type: boolean `true`, expected i64\", line: 0, column: 0)"`
```
      "comments": {
        "can_close": 1,
        "can_post": 1,
        "count": 0,
        "groups_can_post": true
      },
```